### PR TITLE
Remove `phpstan` references.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
     },
     "scripts": {
         "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
-        "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint"
@@ -50,8 +49,7 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "pestphp/pest-plugin": true,
-            "phpstan/extension-installer": true
+            "pestphp/pest-plugin": true
         }
     },
     "extra": {


### PR DESCRIPTION
Since there is no `phpstan` on this project, no need to have the script for that.

(already using the package) 😎

Thanks,
Francisco.