### PR TITLE
Add Support for PHP8.0

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.1]
+        php: [8.0, 8.1]
         laravel: [9.*]
         stability: [prefer-lowest, prefer-stable]
         include:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.1|^8.0",
         "spatie/laravel-package-tools": "^1.13.6",
         "illuminate/contracts": "^9.0"
     },


### PR DESCRIPTION
This is a great package but works only on PHP8.1
This PR adds support for PHP8.0. After reviewing the implementation, there are no breaking changes if the package run with PHP8.0.