### PR TITLE
Remove flags on model delete

### DIFF
--- a/src/Models/Concerns/HasFlags.php
+++ b/src/Models/Concerns/HasFlags.php
@@ -5,10 +5,18 @@ namespace Spatie\ModelFlags\Models\Concerns;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Spatie\ModelFlags\Models\Flag;
+use Illuminate\Database\Eloquent\Model;
 
-/** @mixin \Illuminate\Database\Eloquent\Model */
+/** @mixin Model */
 trait HasFlags
 {
+    public static function bootHasFlags()
+    {
+        static::deleted(function (Model $deletedModel) {
+            $deletedModel->flags()->delete();
+        });
+    }
+
     public function flags(): MorphMany
     {
         return $this->morphMany(config('model-flags.flag_model'), 'flaggable');

--- a/tests/HasFlagsTest.php
+++ b/tests/HasFlagsTest.php
@@ -76,3 +76,15 @@ it('has a scope to get models without a certain flag', function () {
     $this->otherModel->flag('flag-a');
     expect(TestModel::notFlagged('flag-a')->get())->toHaveCount(0);
 });
+
+it('can_remove_flags_on_model_delete', function () {
+    $this->model->flag('flag-a');
+
+    $this->model->delete();
+
+    $this->assertEquals(0, $this->model->flags()->get()->count());
+});
+
+it('can_remove_model_without_flags', function () {
+    expect($this->model->delete())->toBeTrue();
+});


### PR DESCRIPTION
This PR is removing all attached flags on model delete since we don't need them anymore if the model doesn't exist. Hopefully, this will work for you.

Let me know if you have any questions or suggestions.

Thanks!