### PR TITLE
Add enum support for flags

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [8.0, 8.1, 8.2, 8.3]
+        php: [8.1, 8.2, 8.3]
         laravel: ['9.*', '10.*', '11.*']
         stability: [prefer-stable]
         include:
@@ -28,10 +28,6 @@ jobs:
         exclude:
           - laravel: 10.*
             php: 8.3
-          - laravel: 10.*
-            php: 8.0
-          - laravel: 11.*
-            php: 8.0
           - laravel: 11.*
             php: 8.1
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "spatie/laravel-package-tools": "^1.13.6",
         "illuminate/contracts": "^9.0|^10.0|^11.0"
     },

--- a/src/Models/Concerns/HasFlags.php
+++ b/src/Models/Concerns/HasFlags.php
@@ -73,7 +73,7 @@ trait HasFlags
             ->toArray();
     }
 
-    public function latestFlag(string $name = null): ?Flag
+    public function latestFlag(?string $name = null): ?Flag
     {
         return $this
             ->flags()

--- a/tests/Datasets/Flags.php
+++ b/tests/Datasets/Flags.php
@@ -1,0 +1,8 @@
+<?php
+
+use Spatie\ModelFlags\Tests\TestSupport\TestBackedEnum;
+
+dataset('flags', [
+    'a string' => 'flag-a',
+    'a backed enum' => TestBackedEnum::test_case,
+]);

--- a/tests/HasFlagsTest.php
+++ b/tests/HasFlagsTest.php
@@ -10,28 +10,28 @@ beforeEach(function () {
     $this->otherModel = TestModel::create();
 });
 
-it('can add a flag to a model', function () {
-    expect($this->model->hasFlag('flag-a'))->toBeFalse();
+it('can add a flag to a model', function (string|BackedEnum $flag) {
+    expect($this->model->hasFlag($flag))->toBeFalse();
 
-    $this->model->flag('flag-a');
+    $this->model->flag($flag);
 
-    expect($this->model->hasFlag('flag-a'))->toBeTrue();
+    expect($this->model->hasFlag($flag))->toBeTrue();
     expect($this->model->hasFlag('flag-B'))->toBeFalse();
-    expect($this->otherModel->hasFlag('flag-a'))->toBeFalse();
-});
+    expect($this->otherModel->hasFlag($flag))->toBeFalse();
+})->with('flags');
 
-it('can unflag a model', function () {
-    $this->model->unflag('flag-a');
+it('can unflag a model', function (string|BackedEnum $flag) {
+    $this->model->unflag($flag);
 
-    $this->model->flag('flag-a');
+    $this->model->flag($flag);
     $this->model->flag('flag-b');
-    expect($this->model->hasFlag('flag-a'))->toBeTrue();
+    expect($this->model->hasFlag($flag))->toBeTrue();
 
-    $this->model->unflag('flag-a');
+    $this->model->unflag($flag);
 
-    expect($this->model->hasFlag('flag-a'))->toBeFalse();
+    expect($this->model->hasFlag($flag))->toBeFalse();
     expect($this->model->hasFlag('flag-b'))->toBeTrue();
-});
+})->with('flags');
 
 it('can get the flags from a model', function () {
     $this->model

--- a/tests/TestSupport/TestBackedEnum.php
+++ b/tests/TestSupport/TestBackedEnum.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\ModelFlags\Tests\TestSupport;
+
+enum TestBackedEnum: string
+{
+    case test_case = 'test-flag';
+}


### PR DESCRIPTION
This might be somewhat controversial.

I love the ability to use enums directly when checking things, such as the recent ability to [use enums for `authorize()`](https://github.com/laravel/framework/pull/53330). This adds a similar capability to flagging/unflagging/checking flags on models.

The caveat is that `BackedEnum` was introduced in PHP 8.1, which would theoretically be a breaking change here. While it would be ideal to use `Illuminate\Support\enum_value`, it's marked as `@internal` for reasons not immediately clear.

Thanks for your consideration!